### PR TITLE
Test/1

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,13 +15,15 @@
     "uuid": "^8.3.2"
   },
   "engines": {
-    "node": "<=1.0.0"
+    "node": ">=16.0.0"
   },
   "devDependencies": {
     "jest": "^28.1.0",
     "nodemon": "^2.0.16"
   },
-  "scripts": {},
+  "scripts": {
+    "start": "nodemon ./src/app.js"
+  },
   "author": "",
   "license": "ISC"
 }

--- a/src/app.js
+++ b/src/app.js
@@ -15,7 +15,7 @@ const whitelist = [
 
 app.use(cors({
   origin: function (origin, callback) {
-    const allowed = whitelist.indexOf(origin) !== -1
+    const allowed = whitelist.indexOf(origin) !== -1 || !origin
     if (allowed) return callback(null, true);
 
     callback(new Error('Not allowed by CORS'))


### PR DESCRIPTION
O container da API não estava rodando, apenas o da base de dados. Para resolver isso corrigi a versão do node na chave "engines" do package.json e adicionei o script "start". Isso foi necessário porque no Dockerfile está tentando rodar com o script start, mas ele não existia.

O outro problema é que depois de rodar a API com sucesso, eu era bloqueado pelo CORS. Isso acontece porque a origin que ele recebia na função estava vindo undefined, e esse valor não estava na whitelist (na verdade ela está vazia). A origin é undefined quando se faz uma requisição na mesma máquina que a API está rodando. Então adicionei uma pequena regra na validação da origin para corrigir isso.