### PR TITLE
fix: docker-compose and mysql port issue

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - main:/var/lib/mysql
       - ./db/:/docker-entrypoint-initdb.d/
     ports:
-      - 3305:3305
+      - 3306:3306
     healthcheck:
       test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost"]
       timeout: 1s
@@ -34,10 +34,10 @@ services:
       mysql:
         condition: service_healthy
     environment:
-      WRITER_MYSQL_HOST: "mysql"
-      WRITER_MYSQL_PASS: "root"
-      WRITER_MYSQL_PORT: "3305"
-      WRITER_MYSQL_USER: "root"
+      WRITER_MYSQL_HOST: mysql
+      WRITER_MYSQL_PASS: admin
+      WRITER_MYSQL_PORT: "3306"
+      WRITER_MYSQL_USER: admin
       NODE_ENV: "development"
       PORT: "8081"
     links:
@@ -49,4 +49,3 @@ services:
 volumes:
   control-posts-node-modules:
   main:
-      

--- a/src/modules/common/handlers/knex/knex.js
+++ b/src/modules/common/handlers/knex/knex.js
@@ -8,11 +8,11 @@ const knex = require('knex')({
       port: process.env.WRITER_MYSQL_PORT,
       password: process.env.WRITER_MYSQL_PASS,
       database: 'main'
-  },
-  pool: {
-    min: 1,
-    max: 4,
-  },
+    },
+    pool: {
+      min: 1,
+      max: 4,
+    }
 });
 
 const getTransaction = async () => {
@@ -22,7 +22,7 @@ const getTransaction = async () => {
     return {transaction};
 }
 
-const commitTransaction = ({ transaction }) => transaction.rollback();
+const commitTransaction = ({ transaction }) => transaction.commit();
 
 const rollbackTransaction = ({ transaction }) => transaction.rollback();
 

--- a/src/modules/repositories/User/createUsersRepositories/createUsersRepositories.js
+++ b/src/modules/repositories/User/createUsersRepositories/createUsersRepositories.js
@@ -14,7 +14,7 @@ const createUserRepositories = async ({
         const {
             user_created
         } = await transaction('users').insert(user)
-        
+
         const has_response = Array.isArray(user_created) && user_created.length > 0;
 
         if (!has_response) {


### PR DESCRIPTION
A conexão com a base de dados não estava sendo bem sucedida. O problema era por causa da porta. Mudando para 3306 deu certo. Agora mesmo se conectando por fora da API está funcionando.

Além disso, um pequeno detalhe foi mudado no arquivo knex.js. Na função `commitTransaction` estava retornando `transaction.rollback()`, sendo que logicamente o correto seria `transaction.commit()`.