### PR TITLE
fix: schema.sql

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -17,5 +17,3 @@ USER node
 COPY --chown=node:node . .
 
 CMD ["dumb-init", "npm", "start"]
-
-

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,14 +1,15 @@
 USE `main`;
 
-CREATE TABLE posts (
-    id INT PRIMARY KEY AUTO_INCREMENT,
-    author_id INT NOT NULL,
-    post_text VARCHAR(200)
-);
-
 CREATE TABLE users (
-    id VARCHAR(100) PRIMARY KEY AUTO_INCREMENT,
+    id INT PRIMARY KEY AUTO_INCREMENT,
     full_name VARCHAR(100),
     user_email VARCHAR(100) NOT NULL,
     user_password VARCHAR(200) NOT NULL
+);
+
+CREATE TABLE posts (
+    id INT PRIMARY KEY AUTO_INCREMENT,
+    author_id INT NOT NULL,
+    post_text VARCHAR(200),
+    FOREIGN KEY (author_id) REFERENCES users(id) ON DELETE CASCADE
 );


### PR DESCRIPTION
A chave primária na tabela `users` estava definida como `VARCHAR(100) PRIMARY KEY AUTO_INCREMENT`. Isso não faz sentido, ainda mais porque a coluna `autor_id` na tabela `posts` é tipada como um `INT`, e também no _swagger_ é esperado um id do tipo inteiro nas requisições que tem a chave `autor_id`. Agora ela está corretamente definida como um `INT`.

Também foi adicionada uma constraint de foreign key na coluna `author_id` da tabela `posts`, referenciando a coluna `id` da tabela `users`.