### PR TITLE
fix: user creation

### DIFF
--- a/src/modules/handlers/User/createUser.js
+++ b/src/modules/handlers/User/createUser.js
@@ -3,7 +3,7 @@ const httpStatusCodes = require('http-status-codes');
 const { httpErrorHandler } = require("../../common/handlers");
 const { createUserService } = require('../../services');
 
-const createUserHandler = (req, res, next) => {
+const createUserHandler = async (req, res, next) => {
     try{
         const {
             user_email,
@@ -11,7 +11,7 @@ const createUserHandler = (req, res, next) => {
             full_name
         } = req.body
 
-        const created_user = createUserService({
+        const created_user = await createUserService({
             user_email,
             user_password,
             full_name

--- a/src/modules/repositories/User/createUsersRepositories/createUsersRepositories.js
+++ b/src/modules/repositories/User/createUsersRepositories/createUsersRepositories.js
@@ -11,9 +11,7 @@ const createUserRepositories = async ({
     const { transaction } = await getTransaction();
 
     try {
-        const {
-            user_created
-        } = await transaction('users').insert(user)
+        const user_created = await transaction('users').insert(user)
 
         const has_response = Array.isArray(user_created) && user_created.length > 0;
 


### PR DESCRIPTION
O `createUserService` é uma função assíncrona, mas o `createUserHandler` estava chamando ele sem usar `async` e `await`, então não retornava nada, já que não dava tempo para a promessa se cumprir.

Mesmo assim, o usuário ainda não era criado com sucesso. O problema era que no `createUserRepositories`, havia uma linha onde o resultado da função `transaction('users').insert(user)` estava sendo descontruído como se fosse um objeto literal. Mas a função retorna um array, tanto é que existem verificações logo abaixo para ver se de fato retornou um array com algum resultado.

Com correções mínimas esses problemas foram sanados e agora o usuário está sendo de fato persistido no banco.