### PR TITLE
fix: list user by id

### DIFF
--- a/src/modules/handlers/User/listUsers.js
+++ b/src/modules/handlers/User/listUsers.js
@@ -2,20 +2,20 @@
 
 const httpStatusCodes = require('http-status-codes');
 const { httpErrorHandler } = require('../../common/handlers');
-const { 
-    getUserByIdService, 
-    getAllUsersService 
+const {
+    getUserByIdService,
+    getAllUsersService
 } = require('../../services');
 
 const listUserHandler = async (req, res, next) => {
-    try{
+    try {
         const {
             user_id
         } = req.query;
-        
-        const has_user_id = !!user_id && Number.isFinite(+user_id) && false;
 
-        const user_response = has_user_id && getUserByIdService({ user_id });
+        const has_user_id = !!user_id && Number.isFinite(+user_id);
+
+        const user_response = has_user_id && await getUserByIdService({ user_id });
 
         const users_response = !has_user_id && await getAllUsersService();
 
@@ -25,7 +25,7 @@ const listUserHandler = async (req, res, next) => {
         ];
 
         return res.status(httpStatusCodes.OK).send({users});
-    }catch(error){
+    } catch (error) {
         return httpErrorHandler({ req, res, error })
     }
 }

--- a/src/modules/repositories/User/getUserRepositories/getUserRepositories.js
+++ b/src/modules/repositories/User/getUserRepositories/getUserRepositories.js
@@ -1,4 +1,4 @@
-const { 
+const {
     client
 } = require('../../../common/handlers')
 
@@ -7,23 +7,19 @@ const getUserRepositories = async ({
     user_id
 } = {}) => {
 
-    const {
-        response
-    } = await client('users').where({ id: user_id })
+    const response = await client('users').where({ id: user_id })
 
     const has_response = Array.isArray(response) && response.length > 0;
 
-    if(!has_response){
+    if (!has_response) {
         return {
             users: []
         }
     }
 
-    // return {
-    //     users: response
-    // }
-    return undefined;
-
+    return {
+        users: response
+    }
 }
 
 module.exports = {


### PR DESCRIPTION
Na linha 16 do handler de listagem de usuários havia uma expressão booleana que sempre seria falsa, ela impedia que o id passado na query fosse usado.

Nesse mesmo arquivo, estava faltando um `await` no momento de chamar o `getUserByIdService`.

Já no `getUserRepositories` havia um bloco de código comentado, e abaixo dele um `return undefined`. Isso não fazia sentido. Descomentei o código e retirei o `return undefined`. Isso impedia que o resultado da query, mesmo sendo bem sucedido, fosse retornado corretamente.

Outro problema algumas linhas acima, no mesmo arquivo, era no momento de capturar o resultado da busca no banco. O resultado estava sendo desconstruído como um objeto literal, sendo que o retorno é um array.

Agora é possível buscar usuários pelo id.