### PR TITLE
fix: users update

### DIFF
--- a/src/modules/repositories/User/updateUserRepositories/updateUserRepositories.js
+++ b/src/modules/repositories/User/updateUserRepositories/updateUserRepositories.js
@@ -14,7 +14,7 @@ const updateUserRepositories = async ({
 
     try {
 
-        await transaction('users').update({
+        await transaction('users').where({ id }).update({
             user_email,
             user_password,
             full_name

--- a/src/modules/services/User/updateUserService/updateUserService.js
+++ b/src/modules/services/User/updateUserService/updateUserService.js
@@ -21,9 +21,7 @@ const updateUserService = async ({
         throw new Error("Missing user to update")
     }
 
-    const [user_to_update] = users;
-
-    const crypt_password = bcrypt.hashSync(user_to_update.user_password, salt);
+    const crypt_password = bcrypt.hashSync(user_password, salt);
 
     await updateUserRepositories({
         id,
@@ -36,7 +34,7 @@ const updateUserService = async ({
         updatedUser: {
             id,
             user_email,
-            user_password,
+            user_password: crypt_password,
             full_name
         }
     };


### PR DESCRIPTION
O service de atualização de usuário estava retornando a senha sem hash, agora isso foi corrigido. Também nesse mesmo service, estava sendo feita a criptografia da senha antiga do usuário, não da senha que foi passada no corpo da requisição. Além disso, percebi que todos os usuários estavam sendo atualizados ao fazer um `put`. Acontece que no `updateUserRepositories` estava faltando colocar um `where` na query de update. Agora está tudo certo.