### PR TITLE
fix: post creation

### DIFF
--- a/src/modules/repositories/Post/createPostRepositories/createPostRepositories.js
+++ b/src/modules/repositories/Post/createPostRepositories/createPostRepositories.js
@@ -12,8 +12,8 @@ const createPostRepositories = async ({
 
     try {
         const post_created = await transaction('posts').insert(post)
-        
-        const has_response = !Array.isArray(post_created) && post_created.length > 0;
+
+        const has_response = Array.isArray(post_created) && post_created.length > 0;
 
         if (!has_response) {
             return {
@@ -21,6 +21,7 @@ const createPostRepositories = async ({
             }
         }
 
+        await commitTransaction({ transaction })
 
         return {
             post_created

--- a/src/modules/services/Post/createPostService/createPostService.js
+++ b/src/modules/services/Post/createPostService/createPostService.js
@@ -14,7 +14,7 @@ const createPostService = async (post) => {
     })
 
     const has_author = Array.isArray(user) && user.length > 0;
-    
+
     if(has_author === false) {
         throw new Error("Hasn't author in database")
     }
@@ -30,7 +30,7 @@ const createPostService = async (post) => {
     if(has_post_created === false){
         return {
             post_created_id: []
-        }  
+        }
     }
 
     return {


### PR DESCRIPTION
Havia uma expressão booleana incorreta na linha 16 do `createPostRepositories`. Ela estava verificando se o retorno da query _não_ era um array, sendo que deveria verificar se _era_ um array. Além disso, estava faltando chamar o `commitTransaction`. Sem ele as mudanças não são persistidas no banco.