### PR TITLE
fix: list user's posts

### DIFF
--- a/src/modules/repositories/Post/getPostByUserIdRepositories/getPostByUserIdRepositories.js
+++ b/src/modules/repositories/Post/getPostByUserIdRepositories/getPostByUserIdRepositories.js
@@ -1,4 +1,4 @@
-const { 
+const {
     client
 } = require('../../../common/handlers')
 
@@ -10,16 +10,14 @@ const getPostByUserIdRepositories = async ({
 
     const has_response = Array.isArray(response) && response.length > 0;
 
-    if(!has_response){
+    if (!has_response) {
         return {
             posts: []
         }
     }
 
-    const posts = response.forEach(post => post);
-
     return {
-        posts
+        posts: response
     }
 
 }


### PR DESCRIPTION
`getPostByUserIdRepositories` estava fazendo um loop desnecessário na resposta da consulta no banco. Além disso, `forEach` não tem retorno, então não faz sentido designar o retorno dele para uma variável.

Por isso o loop foi removido e o retorno da função foi ajustado.