### PR TITLE
fix: minor issue in delete post repository

### DIFF
--- a/src/modules/repositories/Post/deletePostRepositories/deletePostRepositories.js
+++ b/src/modules/repositories/Post/deletePostRepositories/deletePostRepositories.js
@@ -4,16 +4,16 @@ const {
     rollbackTransaction
 } = require('../../../common/handlers')
 
-const deletePostRepositories = async (
+const deletePostRepositories = async ({
     post_id
-) => {
+}) => {
     const { transaction } = await getTransaction();
 
     try {
-        await transaction('posts').del()
+        await transaction('posts').where({ id: post_id }).del()
 
         await commitTransaction({transaction})
-        
+
     } catch (err) {
         rollbackTransaction({transaction})
         throw new Error(err)


### PR DESCRIPTION
Estava faltando adicionar um `where` na query de deleção de posts. Todos os posts estavam sendo deletados. Além disso, o parâmetro da função `deletePostRepositories` não estava sendo desconstruído. Desconstruí-lo facilita na hora de passar o id no where.
