### PR TITLE
fix: add localhost:8081 to whitelist

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -10,7 +10,7 @@ const port = Number(process.env.PORT || 8089)
 const app = express();
 
 const whitelist = [
-  // TODO whitelist
+  'http://localhost:8081'
 ]
 
 app.use(cors({


### PR DESCRIPTION
Isso foi necessário para que fosse possível fazer requisições através do swagger.