### PR TITLE
fix: adjust swagger request and responses samples

### DIFF
--- a/src/config/swagger.yaml
+++ b/src/config/swagger.yaml
@@ -30,6 +30,31 @@ definitions:
         type: "string"
       user_password:
         type: "string"
+
+  user_create:
+    additionalProperties: false
+    type: object
+    required:
+      - "full_name"
+      - "user_email"
+      - "user_password"
+    properties:
+      full_name:
+        type: "string"
+      user_email:
+        type: "string"
+      user_password:
+        type: "string"
+
+  user_id:
+    additionalProperties: false
+    type: "object"
+    properties:
+      user_created_id:
+        type: "array"
+        items:
+          type: integer
+
   post:
     additionalProperties: false
     type: "object"
@@ -43,6 +68,28 @@ definitions:
         type: "integer"
       post_text:
         type: "string"
+
+  post_create:
+    additionalProperties: false
+    type: object
+    required:
+      - post_text
+      - author_id
+    properties:
+      post_text:
+        type: string
+      author_id:
+        type: integer
+
+  post_id:
+    additionalProperties: false
+    type: "object"
+    properties:
+      post_created_id:
+        type: "array"
+        items:
+          type: integer
+
 paths:
   /user:
     get:
@@ -74,12 +121,12 @@ paths:
           name: user
           description: create user
           schema:
-            $ref: "#/definitions/user"
+            $ref: "#/definitions/user_create"
       responses:
         200:
           description: "success"
           schema:
-            $ref: "#/definitions/user"
+            $ref: "#/definitions/user_id"
     put:
       tags:
         - "Users"
@@ -111,7 +158,11 @@ paths:
         200:
           description: "success"
           schema:
-            $ref: "#/definitions/user"
+            type: "object"
+            properties:
+              updatedUser:
+                $ref: "#/definitions/user"
+
     delete:
       tags:
         - "Users"
@@ -127,7 +178,10 @@ paths:
         200:
           description: "success"
           schema:
-            $ref: "#/definitions/user"
+            type: "object"
+            properties:
+              deletedUser:
+                $ref: "#/definitions/user"
   /post:
     get:
       tags:
@@ -158,21 +212,12 @@ paths:
           name: post
           description: create post
           schema:
-            type: object
-            additionalProperties: false
-            required:
-              - post_text
-              - author_id
-            properties:
-              post_text:
-                type: string
-              author_id:
-                type: integer
+            $ref: "#/definitions/post_create"
       responses:
         200:
           description: "success"
           schema:
-            $ref: "#/definitions/post"
+            $ref: "#/definitions/post_id"
     put:
       tags:
         - "Posts"
@@ -201,7 +246,10 @@ paths:
         200:
           description: "success"
           schema:
-            $ref: "#/definitions/post"
+            type: "object"
+            properties:
+              updatedPost:
+                $ref: "#/definitions/post"
     delete:
       tags:
         - "Posts"
@@ -217,4 +265,7 @@ paths:
         200:
           description: "success"
           schema:
-            $ref: "#/definitions/post"
+            type: "object"
+            properties:
+              deletedPost:
+                $ref: "#/definitions/post"


### PR DESCRIPTION
Os exemplos do swagger não estavam condizendo com a realidade. No retorno da criação de posts e de usuários é retornado apenas o id deles, mas no swagger estava mostrando um objeto completo. Também na criação de usuário, no corpo da requisição, estava mostrando o id, o que não faz sentido, já que o id só é gerado depois que o usuário é criado. Além disso, no retorno da deleção e atualização de usuários e posts, agora está retornando corretamente, com as informações dentro de um objeto.