### PR TITLE
Test/14

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -4,6 +4,7 @@ const SwaggerExpress = require('swagger-express-mw');
 const SwaggerUi = require('swagger-ui-express');
 const express = require('express');
 const { buildHandlers } = require('./modules');
+const { ApplicationError } = require('./modules/common/errors/application-error');
 const { handlers } = buildHandlers();
 const port = Number(process.env.PORT || 8089)
 
@@ -18,7 +19,7 @@ app.use(cors({
     const allowed = whitelist.indexOf(origin) !== -1 || !origin
     if (allowed) return callback(null, true);
 
-    callback(new Error('Not allowed by CORS'))
+    callback(new ApplicationError(400, 'Not allowed by CORS'))
   }
 }))
 

--- a/src/app.js
+++ b/src/app.js
@@ -5,6 +5,9 @@ const SwaggerUi = require('swagger-ui-express');
 const express = require('express');
 const { buildHandlers } = require('./modules');
 const { ApplicationError } = require('./modules/common/errors/application-error');
+const httpStatusCodes = require('http-status-codes');
+
+
 const { handlers } = buildHandlers();
 const port = Number(process.env.PORT || 8089)
 
@@ -19,7 +22,7 @@ app.use(cors({
     const allowed = whitelist.indexOf(origin) !== -1 || !origin
     if (allowed) return callback(null, true);
 
-    callback(new ApplicationError(400, 'Not allowed by CORS'))
+    callback(new ApplicationError(httpStatusCodes.BAD_REQUEST, 'Not allowed by CORS'))
   }
 }))
 

--- a/src/modules/common/errors/application-error.js
+++ b/src/modules/common/errors/application-error.js
@@ -1,0 +1,9 @@
+class ApplicationError {
+  constructor (statusCode, message, details) {
+    this.statusCode = statusCode
+    this.message = message
+    this.details = details
+  }
+}
+
+module.exports = { ApplicationError }

--- a/src/modules/common/handlers/http-error-handler/http-error-handler.js
+++ b/src/modules/common/handlers/http-error-handler/http-error-handler.js
@@ -4,19 +4,23 @@ const uuid = require('uuid');
 const httpErrorHandler = ({ req, res, error }) => {
 
   const response_status_code = error.statusCode || httpStatusCodes.INTERNAL_SERVER_ERROR;
-  const is_internal = error.statusCode === httpStatusCodes.INTERNAL_SERVER_ERROR;
+  const is_internal = response_status_code === httpStatusCodes.INTERNAL_SERVER_ERROR;
   const error_id = uuid.v4();
 
-  const response = {
-    type: `internal server error (${error_id})`,
-  };
+  const response = {};
 
   if (!is_internal) {
     Object.assign(response, {
       message: error.message,
       details: error.details || error,
     });
+  } else {
+    Object.assign(response, {
+      type: `internal server error (${error_id})`,
+    })
   }
+
+
   const error_context = {
     error: String(error),
     error_id,

--- a/src/modules/services/Post/createPostService/createPostService.js
+++ b/src/modules/services/Post/createPostService/createPostService.js
@@ -1,5 +1,6 @@
 const { getUserByIdService } = require("../../User/getUserByIdService/getUserByIdService");
 const { createPostRepositories } = require("../../../repositories");
+const { ApplicationError } = require("../../../common/errors/application-error");
 
 const createPostService = async (post) => {
 
@@ -16,7 +17,7 @@ const createPostService = async (post) => {
     const has_author = Array.isArray(user) && user.length > 0;
 
     if(has_author === false) {
-        throw new Error("Hasn't author in database")
+        throw new ApplicationError(404, "Hasn't author in database")
     }
 
     const {

--- a/src/modules/services/Post/createPostService/createPostService.js
+++ b/src/modules/services/Post/createPostService/createPostService.js
@@ -1,6 +1,7 @@
 const { getUserByIdService } = require("../../User/getUserByIdService/getUserByIdService");
 const { createPostRepositories } = require("../../../repositories");
 const { ApplicationError } = require("../../../common/errors/application-error");
+const httpStatusCodes = require('http-status-codes');
 
 const createPostService = async (post) => {
 
@@ -17,7 +18,7 @@ const createPostService = async (post) => {
     const has_author = Array.isArray(user) && user.length > 0;
 
     if(has_author === false) {
-        throw new ApplicationError(404, "Hasn't author in database")
+        throw new ApplicationError(httpStatusCodes.NOT_FOUND, "Hasn't author in database")
     }
 
     const {

--- a/src/modules/services/Post/deletePostService/deletePostService.js
+++ b/src/modules/services/Post/deletePostService/deletePostService.js
@@ -1,3 +1,4 @@
+const { ApplicationError } = require("../../../common/errors/application-error");
 const { getPostByPostIdRepositories, deletePostRepositories } = require("../../../repositories");
 
 const deletePostService = async ({
@@ -13,7 +14,7 @@ const deletePostService = async ({
     const has_post = Array.isArray(posts) && posts.length === 1;
 
     if(!has_post){
-        throw new Error("Hasn't post to delete")
+        throw new ApplicationError(404, "Hasn't post to delete")
     }
 
     const [post_to_delete] = posts;

--- a/src/modules/services/Post/deletePostService/deletePostService.js
+++ b/src/modules/services/Post/deletePostService/deletePostService.js
@@ -1,5 +1,6 @@
 const { ApplicationError } = require("../../../common/errors/application-error");
 const { getPostByPostIdRepositories, deletePostRepositories } = require("../../../repositories");
+const httpStatusCodes = require('http-status-codes');
 
 const deletePostService = async ({
     post_id
@@ -14,7 +15,7 @@ const deletePostService = async ({
     const has_post = Array.isArray(posts) && posts.length === 1;
 
     if(!has_post){
-        throw new ApplicationError(404, "Hasn't post to delete")
+        throw new ApplicationError(httpStatusCodes.NOT_FOUND, "Hasn't post to delete")
     }
 
     const [post_to_delete] = posts;

--- a/src/modules/services/Post/listPostService/listPostService.js
+++ b/src/modules/services/Post/listPostService/listPostService.js
@@ -1,5 +1,6 @@
 const { getUserByIdService } = require("../../User/getUserByIdService/getUserByIdService");
 const { getPostByUserIdRepositories } = require("../../../repositories");
+const { ApplicationError } = require("../../../common/errors/application-error");
 
 const getPostByUserIdService = async ({
     user_id
@@ -14,7 +15,7 @@ const getPostByUserIdService = async ({
     const has_author = Array.isArray(user) && user.length > 0;
 
     if(has_author === false) {
-        throw new Error("Missing author in database")
+        throw new ApplicationError(404, "Missing author in database")
     }
 
     const {

--- a/src/modules/services/Post/listPostService/listPostService.js
+++ b/src/modules/services/Post/listPostService/listPostService.js
@@ -1,6 +1,7 @@
 const { getUserByIdService } = require("../../User/getUserByIdService/getUserByIdService");
 const { getPostByUserIdRepositories } = require("../../../repositories");
 const { ApplicationError } = require("../../../common/errors/application-error");
+const httpStatusCodes = require('http-status-codes');
 
 const getPostByUserIdService = async ({
     user_id
@@ -15,7 +16,7 @@ const getPostByUserIdService = async ({
     const has_author = Array.isArray(user) && user.length > 0;
 
     if(has_author === false) {
-        throw new ApplicationError(404, "Missing author in database")
+        throw new ApplicationError(httpStatusCodes.NOT_FOUND, "Missing author in database")
     }
 
     const {

--- a/src/modules/services/Post/updatePostService/updatePostService.js
+++ b/src/modules/services/Post/updatePostService/updatePostService.js
@@ -1,5 +1,6 @@
 const { getUserByIdService } = require("../../User/getUserByIdService/getUserByIdService");
 const { getPostByPostIdRepositories, updatePostRepositories } = require("../../../repositories");
+const { ApplicationError } = require("../../../common/errors/application-error");
 
 const updatePostService = async ({
     id,
@@ -16,7 +17,7 @@ const updatePostService = async ({
     const has_post = Array.isArray(posts) && posts.length === 1;
 
     if (!has_post) {
-        throw new Error("Hasn't post to update")
+        throw new ApplicationError(404, "Hasn't post to update")
     }
 
     const {
@@ -28,7 +29,7 @@ const updatePostService = async ({
     const has_author = Array.isArray(user) && user.length === 1;
 
     if (!has_author) {
-        throw new Error("Hasn't author in database")
+        throw new ApplicationError(404, "Hasn't author in database")
     }
 
     await updatePostRepositories({

--- a/src/modules/services/Post/updatePostService/updatePostService.js
+++ b/src/modules/services/Post/updatePostService/updatePostService.js
@@ -1,6 +1,7 @@
 const { getUserByIdService } = require("../../User/getUserByIdService/getUserByIdService");
 const { getPostByPostIdRepositories, updatePostRepositories } = require("../../../repositories");
 const { ApplicationError } = require("../../../common/errors/application-error");
+const httpStatusCodes = require('http-status-codes');
 
 const updatePostService = async ({
     id,
@@ -17,7 +18,7 @@ const updatePostService = async ({
     const has_post = Array.isArray(posts) && posts.length === 1;
 
     if (!has_post) {
-        throw new ApplicationError(404, "Hasn't post to update")
+        throw new ApplicationError(httpStatusCodes.NOT_FOUND, "Hasn't post to update")
     }
 
     const {
@@ -29,7 +30,7 @@ const updatePostService = async ({
     const has_author = Array.isArray(user) && user.length === 1;
 
     if (!has_author) {
-        throw new ApplicationError(404, "Hasn't author in database")
+        throw new ApplicationError(httpStatusCodes.NOT_FOUND, "Hasn't author in database")
     }
 
     await updatePostRepositories({

--- a/src/modules/services/User/deleteUserService/deleteUserService.js
+++ b/src/modules/services/User/deleteUserService/deleteUserService.js
@@ -1,3 +1,4 @@
+const { ApplicationError } = require("../../../common/errors/application-error");
 const { getUserRepositories, deleteUserRepositories } = require("../../../repositories");
 
 const deleteUserService = async ({
@@ -13,7 +14,7 @@ const deleteUserService = async ({
     const has_user = Array.isArray(users) && users.length === 1;
 
     if(!has_user){
-        throw new Error("No user to delete")
+        throw new ApplicationError(404, "No user to delete")
     }
 
     const [user_to_delete] = users;

--- a/src/modules/services/User/deleteUserService/deleteUserService.js
+++ b/src/modules/services/User/deleteUserService/deleteUserService.js
@@ -1,5 +1,6 @@
 const { ApplicationError } = require("../../../common/errors/application-error");
 const { getUserRepositories, deleteUserRepositories } = require("../../../repositories");
+const httpStatusCodes = require('http-status-codes');
 
 const deleteUserService = async ({
     user_id
@@ -14,7 +15,7 @@ const deleteUserService = async ({
     const has_user = Array.isArray(users) && users.length === 1;
 
     if(!has_user){
-        throw new ApplicationError(404, "No user to delete")
+        throw new ApplicationError(httpStatusCodes.NOT_FOUND, "No user to delete")
     }
 
     const [user_to_delete] = users;

--- a/src/modules/services/User/updateUserService/updateUserService.js
+++ b/src/modules/services/User/updateUserService/updateUserService.js
@@ -1,4 +1,5 @@
 const bcrypt = require('bcryptjs');
+const { ApplicationError } = require('../../../common/errors/application-error');
 const salt = bcrypt.genSaltSync(10);
 const { getUserRepositories, updateUserRepositories } = require("../../../repositories");
 
@@ -18,7 +19,7 @@ const updateUserService = async ({
     const has_user = Array.isArray(users) && users.length === 1;
 
     if (!has_user) {
-        throw new Error("Missing user to update")
+        throw new ApplicationError(404, "Missing user to update")
     }
 
     const crypt_password = bcrypt.hashSync(user_password, salt);

--- a/src/modules/services/User/updateUserService/updateUserService.js
+++ b/src/modules/services/User/updateUserService/updateUserService.js
@@ -2,6 +2,7 @@ const bcrypt = require('bcryptjs');
 const { ApplicationError } = require('../../../common/errors/application-error');
 const salt = bcrypt.genSaltSync(10);
 const { getUserRepositories, updateUserRepositories } = require("../../../repositories");
+const httpStatusCodes = require('http-status-codes');
 
 const updateUserService = async ({
     id,
@@ -19,7 +20,7 @@ const updateUserService = async ({
     const has_user = Array.isArray(users) && users.length === 1;
 
     if (!has_user) {
-        throw new ApplicationError(404, "Missing user to update")
+        throw new ApplicationError(httpStatusCodes.NOT_FOUND, "Missing user to update")
     }
 
     const crypt_password = bcrypt.hashSync(user_password, salt);


### PR DESCRIPTION
Percebi que sempre que a aplicação levantava um erro, era um erro interno do servidor, 500. Havia alguns pequenos problemas de lógica no arquivo `http-error-handler.js`, que fazia o erro ser sempre 500. Além disso, foi criada uma classe para erros customizados, que permite lidar com erros de maneira mais suave. Agora, ao invés de `throw new Error()`, podemos usar a classe `ApplicationError`, e passar como argumentos para o construtor o código de status, uma mensagem, e detalhes opcionais. Agora quando é enviado um id inválido em alguma requisição, por exemplo, ao invés de retornar um erro 500, é retornado um erro 404 com uma mensagem apropriada.