### PR TITLE
feat: add a new validation step in posts update service

### DIFF
--- a/src/modules/repositories/Post/updatePostRepositories/updatePostRepositories.js
+++ b/src/modules/repositories/Post/updatePostRepositories/updatePostRepositories.js
@@ -19,6 +19,7 @@ const updatePostRepositories = async ({
             post_text
         })
 
+        await commitTransaction({transaction})
 
     } catch (err) {
         rollbackTransaction({ transaction })

--- a/src/modules/services/Post/updatePostService/updatePostService.js
+++ b/src/modules/services/Post/updatePostService/updatePostService.js
@@ -33,6 +33,12 @@ const updatePostService = async ({
         throw new ApplicationError(httpStatusCodes.NOT_FOUND, "Hasn't author in database")
     }
 
+    const post_belongs_to_author = user[0].id === posts[0].author_id
+
+    if (!post_belongs_to_author) {
+        throw new ApplicationError(httpStatusCodes.FORBIDDEN, "Can't change a post's author")
+    }
+
     await updatePostRepositories({
         id,
         author_id,


### PR DESCRIPTION
Foi adicionada uma regra de validação a mais na atualização de uma postagem. Agora não é mais possível alterar o autor de um post. Isso realmente faz sentido. Além disso, foi descoberto um pequeno bug no `updatePostRepositories`, onde faltava adicionar apenas uma linha, chamando a função `commitTransaction`. Isso estava impedindo que as mudanças fossem persistidas no banco.